### PR TITLE
Skip bot2-vis gracefully if GTK2+ not found

### DIFF
--- a/bot2-vis/CMakeLists.txt
+++ b/bot2-vis/CMakeLists.txt
@@ -10,7 +10,8 @@ find_package(PkgConfig REQUIRED)
 
 # Check whether GTK is available, if not skip bot_vis
 pkg_check_modules(GTK "gtk+-2.0")
-if (NOT GTK_FOUND)
+find_package(GLUT)
+if (NOT GTK_FOUND OR NOT GLUT_FOUND)
 	message(WARNING "GTK not found, skipping bot2-vis")
 	return()
 endif()

--- a/bot2-vis/CMakeLists.txt
+++ b/bot2-vis/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.0)
+cmake_minimum_required(VERSION 2.6.2)
 
 set(POD_NAME bot2-vis)
 
@@ -7,6 +7,14 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
 include(cmake/pods.cmake)
 
 find_package(PkgConfig REQUIRED)
+
+# Check whether GTK is available, if not skip bot_vis
+pkg_check_modules(GTK "gtk+-2.0")
+if (NOT GTK_FOUND)
+	message(WARNING "GTK not found, skipping bot2-vis")
+	return()
+endif()
+
 
 set(GLUT_LIBRARIES -lglut)
 


### PR DESCRIPTION
Note, this merges into libbot-openhumanoids since libbot-openhumanoids has not been merged upstream to RL/libbot yet
