### PR TITLE
[bugfix] Explicitly linking against X11

### DIFF
--- a/bot2-frames/src/renderer/CMakeLists.txt
+++ b/bot2-frames/src/renderer/CMakeLists.txt
@@ -33,7 +33,7 @@ pods_install_pkg_config_file(bot2-frames-renderers
     
 #build the test-viewer
 add_executable(test-viewer test_viewer.c)
-target_link_libraries(test-viewer ${GLUT_LIBRARIES} bot2-frames-renderers)
+target_link_libraries(test-viewer ${GLUT_LIBRARIES} bot2-frames-renderers X11)
 pods_use_pkg_config_packages(test-viewer 
                                          bot2-vis 
                                          bot2-lcmgl-renderer)

--- a/bot2-lcmgl/src/lcmgl-viewer/CMakeLists.txt
+++ b/bot2-lcmgl/src/lcmgl-viewer/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(bot-lcmgl-viewer
     udp_util.c
     view_menu.c
     )
-target_link_libraries(bot-lcmgl-viewer bot2-lcmgl-renderer)
+target_link_libraries(bot-lcmgl-viewer bot2-lcmgl-renderer X11)
 pods_use_pkg_config_packages(bot-lcmgl-viewer bot2-vis) 
 
 

--- a/bot2-vis/src/rwx-viewer/CMakeLists.txt
+++ b/bot2-vis/src/rwx-viewer/CMakeLists.txt
@@ -3,7 +3,7 @@ add_definitions(-std=gnu99)
 add_executable(bot-rwx-viewer
     main.c
     renderer_rwx.c)
-
+target_link_libraries(bot-rwx-viewer X11)
 pods_use_pkg_config_packages(bot-rwx-viewer bot2-vis)  # need header as well as target link library
 
 pods_install_executables(bot-rwx-viewer)

--- a/bot2-vis/src/testers/CMakeLists.txt
+++ b/bot2-vis/src/testers/CMakeLists.txt
@@ -8,4 +8,5 @@ set(testers
 foreach(tester ${testers})
     add_executable(${tester} "${tester}.c")
     pods_use_pkg_config_packages(${tester} bot2-vis)  # need headers as well as bot2-vis target
+    target_link_libraries(${tester} X11)
 endforeach()

--- a/bot2-vis/src/wavefront-viewer/CMakeLists.txt
+++ b/bot2-vis/src/wavefront-viewer/CMakeLists.txt
@@ -3,7 +3,7 @@ add_definitions(-std=gnu99)
 add_executable(bot-wavefront-viewer
     main.c
     renderer_wavefront.c)
-
+target_link_libraries(bot-wavefront-viewer X11)
 pods_use_pkg_config_packages(bot-wavefront-viewer bot2-vis)  # need headers as well as target link libraries
 
 pods_install_executables(bot-wavefront-viewer)


### PR DESCRIPTION
On Ubuntu 16 fresh install libbot does not compile because of undefine references 